### PR TITLE
Track DelayNs changes in embedded-hal-1.0.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "1.0.0-rc.1"
+embedded-hal = "1.0.0-rc.2"
 embedded-hal-async = { version = "1.0.0-rc.1", optional =  true }
 riscv = { git = "https://github.com/rust-embedded/riscv", branch = "master" }
 

--- a/src/hal/aclint.rs
+++ b/src/hal/aclint.rs
@@ -1,7 +1,7 @@
 //! Delay trait implementation for (A)CLINT peripherals
 
 use crate::aclint::mtimer::MTIME;
-pub use crate::hal::delay::DelayUs;
+pub use crate::hal::delay::DelayNs;
 
 /// Delay implementation for (A)CLINT peripherals.
 pub struct Delay {
@@ -35,11 +35,12 @@ impl Delay {
     }
 }
 
-impl DelayUs for Delay {
+impl DelayNs for Delay {
     #[inline]
-    fn delay_us(&mut self, us: u32) {
+    fn delay_ns(&mut self, ns: u32) {
         let t0 = self.mtime.read();
-        let n_ticks = us as u64 * self.freq as u64 / 1_000_000;
+        let ns_64: u64 = ns.into();
+        let n_ticks = ns_64 * self.freq as u64 / 1_000_000_000;
         while self.mtime.read().wrapping_sub(t0) < n_ticks {}
     }
 }


### PR DESCRIPTION
Tracks delay changes in embedded-hal-1.0.0-rc.2.

Analogous to https://github.com/rust-embedded/riscv/pull/160